### PR TITLE
docs: replace gpt-3.5-turbo with gpt-4o-mini

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -84,7 +84,7 @@ Copy the token for the next step.
 Then, authenticate with the following command:
 
 ```bash
-k8sgpt auth add --backend openai --model gpt-3.5-turbo
+k8sgpt auth add --backend openai --model gpt-4o-mini
 ```
 
 This will request the token that has just been generated. Paste the token into the command line.

--- a/docs/getting-started/in-cluster-operator.md
+++ b/docs/getting-started/in-cluster-operator.md
@@ -42,7 +42,7 @@ metadata:
 spec:
   ai:
     enabled: true
-    model: gpt-3.5-turbo
+    model: gpt-4o-mini
     backend: openai
     secret:
       name: k8sgpt-sample-secret
@@ -50,7 +50,7 @@ spec:
     # anonymized: false
     # language: english
   noCache: false
-  version: v0.3.17
+  version: v0.3.41
   # filters:
   #   - Ingress
   # sink:
@@ -62,7 +62,7 @@ spec:
 EOF
 ```
 
-Please replace the `<VERSION>` field with the [current release of K8sGPT](https://github.com/k8sgpt-ai/k8sgpt/releases). At the time of writing this is `v0.3.17`.
+Please replace the `<VERSION>` field with the [current release of K8sGPT](https://github.com/k8sgpt-ai/k8sgpt/releases). At the time of writing this is `v0.3.41`.
 
 ### Regarding out-of-cluster traffic to AI backends
 

--- a/docs/reference/providers/backend.md
+++ b/docs/reference/providers/backend.md
@@ -19,7 +19,7 @@ Currently, we have a total of 11 backends available:
 
 ## OpenAI
 
-OpenAI is the default backend for K8sGPT. We recommend using OpenAI first if you are new to K8sGPT and if you have an account on [OpenAI](https://openai.com/). OpenAI comes with the access to powerful language models such as GPT-3.5-Turbo, GPT-4. If you are looking for a powerful and easy-to-use language modeling service, OpenAI is a great option.
+OpenAI is the default backend for K8sGPT. We recommend using OpenAI first if you are new to K8sGPT and if you have an account on [OpenAI](https://openai.com/). OpenAI comes with the access to powerful language models such as GPT-4. If you are looking for a powerful and easy-to-use language modeling service, OpenAI is a great option.
 
 - To use OpenAI you'll need an OpenAI token for authentication purposes. To generate a token use:
     ```bash
@@ -153,7 +153,7 @@ Hugging Face is a versatile backend for K8sGPT, offering access to a wide range 
     ```bash
     k8sgpt auth add --backend huggingface --model <model name>
     ```
-> NOTE: Since the default gpt-3.5-turbo model is not available in Hugging Face, a valid backend model is required.
+> NOTE: Since the default gpt-4o-mini model is not available in Hugging Face, a valid backend model is required.
 
 - Once configured, you can analyze issues within your cluster using the Hugging Face provider with the following command:
     ```bash

--- a/docs/tutorials/slack-integration.md
+++ b/docs/tutorials/slack-integration.md
@@ -31,7 +31,7 @@ metadata:
 spec:
   ai:
     enabled: true
-    model: gpt-3.5-turbo
+    model: gpt-4o-mini
     backend: openai
     secret:
       name: k8sgpt-sample-secret


### PR DESCRIPTION
`gpt-3.5-turbo` is not recommended for use as of July 2024 (https://platform.openai.com/docs/models/gpt-3-5-turbo) and it's accuracy has been unreliable in the last couple of months. 
`gpt-4o-mini` is a recommended replacement and it's also ~3 times cheaper so it might be a good idea to use it as default model.
