### PR TITLE
docs: add custom-analyzer and dump commands in k8sgpt 0.3.48

### DIFF
--- a/docs/getting-started/getting-started.md
+++ b/docs/getting-started/getting-started.md
@@ -47,6 +47,8 @@ Available Commands:
   auth        Authenticate with your chosen backend
   cache       For working with the cache the results of an analysis
   completion  Generate the autocompletion script for the specified shell
+  custom-analyzer Manage a custom analyzer
+  dump            Creates a dumpfile for debugging issues with K8sGPT
   filters     Manage filters for analyzing Kubernetes resources
   generate    Generate Key for your chosen backend (opens browser)
   help        Help about any command


### PR DESCRIPTION
In the new version of k8sgpt (0.3.48), two additional commands, `custom-analyzer` and `dump`, were introduced. These commands were missing from the documentation. This pull request adds detailed information about these two commands to ensure the documentation is accurate and up-to-date.

<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
This pull request updates the documentation to include details about the custom-analyzer and dump commands introduced in k8sgpt version 0.3.48. These updates ensure users are aware of these commands and their usage.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [✅ ] My pull request adheres to the code style of this project
- [ ✅] My code requires changes to the documentation
- [✅ ] I have updated the documentation as required
- [✅ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
No breaking changes. This PR is limited to documentation updates only.


